### PR TITLE
Add missing BUILD_ORDER keys: cache_from, labels, shm_size, target

### DIFF
--- a/compose_format/__init__.py
+++ b/compose_format/__init__.py
@@ -41,7 +41,7 @@ class ComposeFormat:
         'interval', 'timeout', 'retries',
         'disable',
     ]
-    BUILD_ORDER = ['context', 'dockerfile', 'args']
+    BUILD_ORDER = ['context', 'dockerfile', 'args', 'cache_from', 'labels', 'shm_size', 'target']
 
     ORDERS = {
         'version': TOPLEVEL_ORDER,


### PR DESCRIPTION
Upstream docs: https://docs.docker.com/compose/compose-file/#build