### PR TITLE
Fix sexadecimal number regex

### DIFF
--- a/compose_format/__init__.py
+++ b/compose_format/__init__.py
@@ -77,7 +77,8 @@ class ComposeFormat:
 
     def format_string(self, data, replace=False, strict=True):
         data = self.reorder(load(data, RoundTripLoader), strict=strict)
-        formatted = dump(data, Dumper=RoundTripDumper, indent=2, width=120)
+        formatted = dump(data, Dumper=RoundTripDumper,
+                         indent=2, block_seq_indent=2, width=120)
 
         return formatted.strip() + '\n'
 

--- a/compose_format/__init__.py
+++ b/compose_format/__init__.py
@@ -112,7 +112,7 @@ class ComposeFormat:
         import re
 
         SEXADECIMAL_NUMBER = '(?P<left>\d+):(?P<right>\d+)'
-        match = re.match(SEXADECIMAL_NUMBER, value)
+        match = re.match(SEXADECIMAL_NUMBER, str(value))
         if not match or int(match.group('left')) > 60 or int(match.group('right')) > 60:
             return value
         return SingleQuotedScalarString('{0}:{1}'.format(match.group('left'), match.group('right')))


### PR DESCRIPTION
The underlaying `ruamel.yaml` library is wrongfully detecting `ipam` map as `CommentedSeq` and so the regex match, inside `fix_sexadecimal_numbers`, is failing when trying to process `ordereddict([('subnet', '172.16.0.0/16')])` instead of string object. So parsing every value to str is a workaround and doesn't break any functionality. Here is the error without the fix:
```
Traceback (most recent call last):
  File "./bin/compose_format", line 35, in <module>
    if not formatter.format(path, replace=args.replace, strict=not args.non_strict):
  File "/usr/local/lib/python3.7/site-packages/compose_format/__init__.py", line 68, in format
    formatted = self.format_string(data, replace=replace, strict=strict)
  File "/usr/local/lib/python3.7/site-packages/compose_format/__init__.py", line 78, in format_string
    data = self.reorder(load(data, RoundTripLoader), strict=strict)
  File "/usr/local/lib/python3.7/site-packages/compose_format/__init__.py", line 99, in reorder
    ComposeFormat.reorder(item, strict)
  File "/usr/local/lib/python3.7/site-packages/compose_format/__init__.py", line 99, in reorder
    ComposeFormat.reorder(item, strict)
  File "/usr/local/lib/python3.7/site-packages/compose_format/__init__.py", line 99, in reorder
    ComposeFormat.reorder(item, strict)
  [Previous line repeated 1 more time]
  File "/usr/local/lib/python3.7/site-packages/compose_format/__init__.py", line 103, in reorder
    data[i] = ComposeFormat.fix_sexadecimal_numbers(value)
  File "/usr/local/lib/python3.7/site-packages/compose_format/__init__.py", line 114, in fix_sexadecimal_numbers
    match = re.match(SEXADECIMAL_NUMBER, value)
  File "/usr/local/lib/python3.7/re.py", line 173, in match
    return _compile(pattern, flags).match(string)
TypeError: expected string or bytes-like object
```